### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "homepage": "https://github.com/fedot/node-uap",
   "dependencies": {
-    "uap-core": "git://github.com/ua-parser/uap-core#2e6c983e42e7aae7d957a263cb4d3de7ccbd92af",
+    "uap-core": "https://github.com/ua-parser/uap-core#22d122028f009ef3c086a24e4354b903ec0941bd",
     "uap-ref-impl": "0.2.0",
     "yamlparser": "0.0.2"
   }


### PR DESCRIPTION
Updating uap-core reference. The previous reference no longer exists... not sure why. I am guessing there was a force push on uap-core's side.

As it currently stands, master does not install:

```
➜  node-uap git:(master) yarn install
➤ YN0000: ┌ Resolution step
➤ YN0001: │ uap-core@git://github.com/ua-parser/uap-core#2e6c983e42e7aae7d957a263cb4d3de7ccbd92af: Failed listing refs
➤ YN0001: │   Repository URL: git://github.com/ua-parser/uap-core
➤ YN0001: │   Fatal Error: unable to connect to github.com:
➤ YN0001: │   Github.com[0 Error: 192.30.255.112]: errno=Operation timed out
➤ YN0001: │   Exit Code: 128
➤ YN0000: └ Completed in 1m 16s
➤ YN0000: Failed with errors in 1m 16s
```

Updating to ref 22d122028f009ef3c086a24e4354b903ec0941bd, which is currently tagged as v0.6.7 and is supposedly the correct version.
