### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "homepage": "https://github.com/fedot/node-uap",
   "dependencies": {
     "array.prototype.find": "2.0.0",
-    "uap-core": "git://github.com/ua-parser/uap-core#2e6c983e42e7aae7d957a263cb4d3de7ccbd92af",
+    "uap-core": "https://github.com/ua-parser/uap-core#2cd82f7da82b37605fa3a43038db18365e5da9d3",
     "uap-ref-impl": "0.2.0",
     "yamlparser": "0.0.2"
   }


### PR DESCRIPTION
Apparently this branch is primarily used by fxa, and appears to have the same problem that was fixed on master yesterday. 

From previous PR:


_Updating uap-core reference. The previous reference no longer exists... not sure why. I am guessing there was a force push on uap-core's side._

_As it currently stands, master does not install:_
```
➜  node-uap git:(master) yarn install
➤ YN0000: ┌ Resolution step
➤ YN0001: │ uap-core@git://github.com/ua-parser/uap-core#2e6c983e42e7aae7d957a263cb4d3de7ccbd92af: Failed listing refs
➤ YN0001: │   Repository URL: git://github.com/ua-parser/uap-core
➤ YN0001: │   Fatal Error: unable to connect to github.com:
➤ YN0001: │   Github.com[0 Error: 192.30.255.112]: errno=Operation timed out
➤ YN0001: │   Exit Code: 128
➤ YN0000: └ Completed in 1m 16s
➤ YN0000: Failed with errors in 1m 16s
```